### PR TITLE
adapted base_url to match the deployment

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 # The URL the site will be built for
-base_url = "http://davescloudportfolio.com"
+base_url = "https://zippy-hummingbird-768d3d.netlify.app"
 description = "A site for showcasing projects."
 author = "Dave Wang (Ru Han Wang)"
 theme = "project-portfolio"


### PR DESCRIPTION
Hi @ruhan-dave,

The reason for the missing styling on your deployment is, that the base_url in your configuration does not match the URL of the deployment. It should work correctly, if you adapt your config.toml as shown in this pull-request.

The reason for your issue is, that the theme uses absolute URLs to access the stylesheet and other resources. It is implemented this way, to allow hosting on URLs of this form as well: https://example.org/my-website

Best,
Adrian